### PR TITLE
Allow ptrace to be run from inside a kuzzle container

### DIFF
--- a/docker-compose/backoffice-docker-compose.yml
+++ b/docker-compose/backoffice-docker-compose.yml
@@ -15,6 +15,12 @@ services:
 
   kuzzle:
     image: kuzzleio/kuzzle
+    cap_add:
+      - SYS_PTRACE
+    depends_on:
+      - proxy
+      - redis
+      - elasticsearch
     environment:
       - kuzzle_services__db__host=elasticsearch
       - kuzzle_services__internalCache__node__host=redis

--- a/docker-compose/kuzzle-docker-compose.yml
+++ b/docker-compose/kuzzle-docker-compose.yml
@@ -8,6 +8,8 @@ services:
 
   kuzzle:
     image: kuzzleio/kuzzle
+    cap_add:
+      - SYS_PTRACE
     depends_on:
       - proxy
       - redis

--- a/docker-compose/kuzzle-ssl-docker-compose.yml
+++ b/docker-compose/kuzzle-ssl-docker-compose.yml
@@ -19,6 +19,8 @@ services:
 
   kuzzle:
     image: kuzzleio/kuzzle
+    cap_add:
+      - SYS_PTRACE
     depends_on:
       - proxy
       - redis


### PR DESCRIPTION
# Description

This PR adds `ptrace` rights to Kuzzle containers, allowing `gcore` to attach itself to a running process and to produce a core dump.
This solves the `ptrace: Operation not permitted` error when running a kuzzle dump from a docker container, running on Ubuntu 14.10 and newer.

This should not affect security since recent kernels have also Yama with ptrace protection, meaning that a process must explicitly provide the rights to `gcore` to attach itself to it, which is done by the [dumpme module](https://github.com/kuzzleio/dumpme).

# Analysis

Docker unconditionnally applies a default AppArmor configuration, confining containers. A bug in older AppArmor versions (installed on Ubuntu Trusty by default) prevented Docker to apply confinement rules on `ptrace` calls for this version of Ubuntu.

AppArmor has been fixed on Ubuntu 14.10 and later, allowing Docker to apply `ptrace` confinement, and preventing Kuzzle diagnostic tools to create live core dumps.

# See also

[ptrace peer=@{profile_name}' does not work on 14.04 (at least)](https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/1390592)
[apparmor denies ptrace to docker-default profile](https://github.com/moby/moby/issues/7276#issuecomment-194137403)
