### PR TITLE
Remove the docker-compose file for the guide

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -18,6 +18,3 @@ You need:
 
 `docker-compose -f kuzzle-ssl-docker-compose.yml up`
 
-## Kuzzle Guide (for contributors)
-
-`docker-compose -f guide-docker-compose.yml up`

--- a/docker-compose/guide-docker-compose.yml
+++ b/docker-compose/guide-docker-compose.yml
@@ -1,6 +1,0 @@
-kuzzleapidocumentation:
-  build: .
-  volumes:
-    - ./source:/app/source
-  ports:
-    - 4567:4567


### PR DESCRIPTION
**Changes:**

* Remove the guide from the provided docker-compose files


**Explanation:**

We had 2 choices, remove the file, or create a docker image available on docker hub. The second solution would imply to have the documentation sources in the image which would complicate the contribution (the objective to have the file here in the first place).