### PR TITLE
Change host name kuzzle services db client host

### DIFF
--- a/docker-compose/backoffice-docker-compose.yml
+++ b/docker-compose/backoffice-docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - redis
       - elasticsearch
     environment:
-      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__db__client__host=elasticsearch
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy

--- a/docker-compose/kuzzle-docker-compose.yml
+++ b/docker-compose/kuzzle-docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - redis
       - elasticsearch
     environment:
-      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__db__client__host=elasticsearch
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy

--- a/docker-compose/kuzzle-ssl-docker-compose.yml
+++ b/docker-compose/kuzzle-ssl-docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - redis
       - elasticsearch
     environment:
-      - kuzzle_services__db__host=elasticsearch
+      - kuzzle_services__db__client__host=elasticsearch
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
       - kuzzle_services__proxyBroker__host=proxy


### PR DESCRIPTION
Because of this PR https://github.com/kuzzleio/kuzzle/pull/859 the docker-compose need an update about environment variable name `kuzzle_services__db__client__host`