### PR TITLE
setup.sh programmatically asks for right to perform operations

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,13 @@ KUZZLE_DIR="${HOME}/.kuzzle"
 COMPOSER_YML_PATH="${KUZZLE_DIR}/docker-compose.yml"
 README_PATH="${KUZZLE_DIR}/README"
 FIRST_INSTALL=0
-HAS_GROUP_DOCKER="$(groups | grep docker)"
+
+docker_out=$(docker info 2>&1)
+if [[ $? > 0 ]] && [[ "$docker_out" =~ "^Got permission denied" ]]; then
+  unset HAS_GROUP_DOCKER
+else
+  HAS_GROUP_DOCKER=1
+fi
 
 DL_BIN=$(command -v curl)
 DL_OPTS="-sSL"
@@ -290,7 +296,7 @@ setupMapCount() {
         echo
         sudo sysctl -w vm.max_map_count=$REQUIRED_MAP_COUNT
         if [ -z "$MAP_COUNT" ]; then
-          sudo echo "vm.max_map_count=$REQUIRED_MAP_COUNT" >> $SYSCTL_CONF_FILE
+          echo "vm.max_map_count=$REQUIRED_MAP_COUNT" | sudo tee -a $SYSCTL_CONF_FILE
         else
           sed 's/vm.max_map_count=.+/vm.max_map_count=$REQUIRED_MAP_COUNT/g' > ${TMPDIR-/tmp}/sysctl.tmp
           sudo mv ${TMPDIR-/tmp}/sysctl.tmp $SYSCTL_CONF_FILE

--- a/setup.sh
+++ b/setup.sh
@@ -278,7 +278,7 @@ setupMapCount() {
     echo
     writeBold "[❓] Do you want to set the vm.max_map_count now? (y/N) "
     if [ $EUID != 0 ]; then
-      write "[ℹ] Installing Docker Compose needs root privileges."
+      write "[ℹ] Setting vm-max-map-count needs root privileges."
       write "    Since you are not running this script with root privileges"
       write "    you are likely to be prompted for your sudo password."
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,10 @@ README_PATH="${KUZZLE_DIR}/README"
 FIRST_INSTALL=0
 HAS_GROUP_DOCKER="$(groups | grep docker)"
 
+DL_BIN=$(command -v curl)
+DL_OPTS="-sSL"
+UL_OPTS='-H Content-Type:application/json --data'
+
 if [ ! -d $KUZZLE_DIR ]; then
   mkdir $KUZZLE_DIR;
 fi
@@ -171,73 +175,11 @@ isOSSupported()
   esac
 }
 
-installDL() {
-  echo
-  writeBold "[ℹ] It is recommended to have cUrl to install Kuzzle. However it"
-  writeBold "    does not seem to be installed on your system."
-  while [[ "$installDL" != [yYnN] ]]
-  do
-    echo
-    writeBold "[❓] Do you want to install cUrl automatically now? (y/N)"
-    echo -n "> "
-    read installDL trash
-    case $installDL in
-      [yY])
-        if [ $EUID != 0 ]; then
-          write "[ℹ] Installing cUrl needs root privileges."
-          write "    Since you are not running this script with root privileges"
-          write "    you are likely to be prompted for your sudo password."
-        fi
-        echo
-        if commandExists apt-get; then
-          sudo apt-get -y install curl
-          setDL curl
-          writeBold "$GREEN" "[✔] cUrl successfully installed."
-        elif commandExists yum; then
-          sudo yum install curl
-          setDL curl
-          writeBold "$GREEN" "[✔] cUrl successfully installed."
-        else
-          echo
-          writeBold "$YELLOW" "[✖] Sorry, no suitable package manager found."
-          echo
-          exit 8
-        fi
-        ;;
-      [nN] | '')
-        echo
-        writeBold "$BLUE" "Ok."
-        echo
-        ;;
-      *)
-        echo
-        writeBold "$RED" "[✖] Please, answer Y or N."
-        ;;
-    esac
-  done
-}
-
-setDL() {
-  if [ "$1" == 'curl' ]; then
-    DL_BIN=$(command -v curl)
-    DL_OPTS="-sSL"
-    UL_OPTS='-H Content-Type:application/json --data'
-  elif [ "$1" == 'wget' ]; then
-    DL_BIN=$(command -v wget)
-    DL_OPTS="-qO-"
-    UL_OPTS="--header=Content-Type:application/json --post-data="
-  else
-    echo
-    writeBold "$RED" "[✖] something went wrong detecting the downlaoder."
-    exit 10
-  fi
-}
-
 failDL() {
   echo
-  writeBold "$YELLOW" "[✖] curl or wget are necessary to install Kuzzle. However,"
-  writeBold "$YELLOW" "     none of them seems to be available on your system."
-  write               "     Please install curl or wget and re-run this script."
+  writeBold "$YELLOW" "[✖] curl is necessary to install Kuzzle. However,"
+  writeBold "$YELLOW" "     it does not seem to be available on your system."
+  write               "     Please install curl and re-run this script."
   echo
   exit 9
 }
@@ -263,7 +205,7 @@ installDocker() {
         else
           writeBold "[ℹ] Installing Docker..."
           echo
-          sudo $DL_BIN $DL_OPTS https://get.docker.com/ | sudo sh
+          $DL_BIN $DL_OPTS https://get.docker.com/ | sudo sh
           if [ $? -eq 0 ]; then
             writeBold "$GREEN" "[✔] Docker successfully installed."
           else
@@ -646,16 +588,11 @@ else
   write "$GREEN" "[✔] Available memory is at least 3Gb."
 fi
 
-if ! commandExists curl && ! commandExists wget; then
-  INSTALL_DL=1
+if ! commandExists curl; then
   write "$YELLOW" "[✖] cUrl is not installed."
   exit 1
 elif commandExists curl; then
-  setDL "curl"
   write "$GREEN" "[✔] cUrl is installed."
-elif commandExists wget; then
-  setDL "wget"
-  write "$GREEN" "[✔] Wget is installed."
 fi
 
 if ! commandExists docker; then
@@ -710,12 +647,6 @@ if [[ "$INSTALL_DOCKER" == 1 || "$INSTALL_DOCKER_COMPOSE" == 1 || "$INSTALL_DL" 
   read trash
   findOSType
   isOSSupported
-fi
-
-if [[ "$INSTALL_DL" == 1 ]]; then
-  echo
-  writeBold "$YELLOW" "[ℹ] cUrl needs to be installed."
-  installDL
 fi
 
 if [[ "$INSTALL_DOCKER" == 1 ]]; then


### PR DESCRIPTION
In the current version, setup.sh needs to be run as root. This looks annoying at first glance, since root privileges are not justified anywhere (we never tell the user _why_ we need those privileges).
This PR improves the script by making it ask for privileges only when it is necessary, namely
* to install docker,
* to install docker-compose,
* to set the `vm_map_max_count` kernel parameter,
* to start kuzzle via docker (if the user is not in the `docker` group)

### Boyscouting
* The short help is now written to a README file in the `~/.kuzzle` directory.
* The script does not prompts the user to pull the last Docker image (not pertinent, IMHO, since setup.sh is meant to be used for _first_ install, not as a general launcher for Kuzzle)