### PR TITLE
Compose - es to 512m

### DIFF
--- a/docker-compose/backoffice-docker-compose.yml
+++ b/docker-compose/backoffice-docker-compose.yml
@@ -26,12 +26,8 @@ services:
     image: redis:3.2-alpine
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.4.1
     environment:
       - cluster.name=kuzzle
-      # disable xpack
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.graph.enabled=false
-      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 

--- a/docker-compose/kuzzle-docker-compose.yml
+++ b/docker-compose/kuzzle-docker-compose.yml
@@ -20,12 +20,8 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.4.1
     environment:
       - cluster.name=kuzzle
-      # disable xpack
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.graph.enabled=false
-      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 

--- a/docker-compose/kuzzle-ssl-docker-compose.yml
+++ b/docker-compose/kuzzle-ssl-docker-compose.yml
@@ -31,11 +31,8 @@ services:
     image: redis:3.2
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.4.1
     environment:
       - cluster.name=kuzzle
-      # disable xpack
-      - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
-      - xpack.graph.enabled=false
-      - xpack.watcher.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+


### PR DESCRIPTION
Use 512m for elasticsearch java heap space by default instead of 2Gb.