### PR TITLE
Make docker-compose stack use Redis 5 by default

### DIFF
--- a/docker-compose/kuzzle-docker-compose.yml
+++ b/docker-compose/kuzzle-docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   kuzzle:
@@ -17,7 +17,7 @@ services:
       - NODE_ENV=production
 
   redis:
-    image: redis:3.2
+    image: redis:${REDIS_VERSION:-5}
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.4.1

--- a/docker-compose/kuzzle-docker-compose.yml
+++ b/docker-compose/kuzzle-docker-compose.yml
@@ -17,10 +17,10 @@ services:
       - NODE_ENV=production
 
   redis:
-    image: redis:${REDIS_VERSION:-5}
+    image: redis:5
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.6.10
     ulimits:
       nofile: 65536
     environment:

--- a/docker-compose/kuzzle-ssl-docker-compose.yml
+++ b/docker-compose/kuzzle-ssl-docker-compose.yml
@@ -28,10 +28,10 @@ services:
       - NODE_ENV=production
 
   redis:
-    image: redis:${REDIS_VERSION:-5}
+    image: redis:5
 
   elasticsearch:
-    image: kuzzleio/elasticsearch:5.4.1
+    image: kuzzleio/elasticsearch:5.6.10
     ulimits:
       nofile: 65536
     environment:

--- a/docker-compose/kuzzle-ssl-docker-compose.yml
+++ b/docker-compose/kuzzle-ssl-docker-compose.yml
@@ -1,7 +1,7 @@
 # HAProxy uses a self signed certificate. You have to accept the exception
 # in your browser. A proper certificate should be used for non development purposes.
 # In this setup, Kuzzle port is using SSL.
-version: '2'
+version: '3'
 
 services:
   haproxy:
@@ -28,7 +28,7 @@ services:
       - NODE_ENV=production
 
   redis:
-    image: redis:3.2
+    image: redis:${REDIS_VERSION:-5}
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.4.1


### PR DESCRIPTION
## What does this PR do ?
Make the docker-compose stack used by setup.sh to use Redis 5 by default.

### How should this be manually tested?

Run the two docker-compose stack and check the image used by Redis container.

### Other changes

Bump Docker-compose file syntax version to 3
